### PR TITLE
fix: read version from package.json instead of hardcoding

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import pkg from '../package.json' with { type: 'json' };
+
+describe('CLI version', () => {
+  it('should display the version from package.json', () => {
+    const output = execSync('bun src/index.ts --version').toString().trim();
+    expect(output).toBe(pkg.version);
+  });
+
+  it('should not display a hardcoded version', () => {
+    const output = execSync('bun src/index.ts --version').toString().trim();
+    expect(output).not.toBe('1.1.0');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { ExitPromptError } from '@inquirer/core';
 import { interactiveCommand, listCategories, maintenanceCommand, uninstallCommand } from './commands/index.js';
 import { initConfig, configExists, listBackups, cleanOldBackups, loadConfig, formatSize } from './utils/index.js';
+import pkg from '../package.json' with { type: 'json' };
 
 function handleCleanExit(error: unknown) {
   if (error instanceof ExitPromptError) {
@@ -31,7 +32,7 @@ const program = new Command();
 program
   .name('mac-cleaner')
   .description('Open source CLI tool to clean your Mac')
-  .version('1.1.0')
+  .version(pkg.version)
   .option('-r, --risky', 'Include risky categories (downloads, iOS backups, etc)')
   .option('-f, --file-picker', 'Force file picker for ALL categories')
   .option('-A, --absolute-paths', 'Show absolute paths instead of truncated notations')

--- a/src/scanners/launch-agents.ts
+++ b/src/scanners/launch-agents.ts
@@ -67,8 +67,7 @@ export class LaunchAgentsScanner extends BaseScanner {
               modifiedAt: stats.mtime,
             });
           }
-        } catch (error) {
-          // Error processing this plist, skip and continue
+        } catch {
           continue;
         }
       }


### PR DESCRIPTION
## Summary

Fixes #40

- Replaces the hardcoded version string `'1.1.0'` in `src/index.ts` with a dynamic import from `package.json`, so `mac-cleaner-cli -V` always displays the correct version
- Adds tests to verify the displayed version matches `package.json`
- Fixes a pre-existing lint error in `launch-agents.ts` (unused catch variable)

## Test plan

- [x] `bun run test` — all 318 tests pass
- [x] `bun run lint` — no errors

Made with [Cursor](https://cursor.com)