### PR TITLE
fix: filePicker config support + TimeMachine snapshots maintenance

### DIFF
--- a/src/commands/maintenance.ts
+++ b/src/commands/maintenance.ts
@@ -1,10 +1,11 @@
 import chalk from 'chalk';
 import ora from 'ora';
-import { flushDnsCache, freePurgeableSpace, type MaintenanceResult } from '../maintenance/index.js';
+import { flushDnsCache, freePurgeableSpace, clearTimeMachineSnapshots, type MaintenanceResult } from '../maintenance/index.js';
 
 interface MaintenanceCommandOptions {
   dns?: boolean;
   purgeable?: boolean;
+  timemachine?: boolean;
 }
 
 export async function maintenanceCommand(options: MaintenanceCommandOptions): Promise<void> {
@@ -18,9 +19,13 @@ export async function maintenanceCommand(options: MaintenanceCommandOptions): Pr
     tasks.push({ name: 'Free Purgeable Space', fn: freePurgeableSpace });
   }
 
+  if (options.timemachine) {
+    tasks.push({ name: 'Clear Time Machine Snapshots', fn: clearTimeMachineSnapshots });
+  }
+
   if (tasks.length === 0) {
     console.log(chalk.yellow('\nNo maintenance tasks specified.'));
-    console.log(chalk.dim('Use --dns to flush DNS cache or --purgeable to free purgeable space.\n'));
+    console.log(chalk.dim('Use --dns, --purgeable, or --timemachine for maintenance tasks.\n'));
     return;
   }
 
@@ -46,5 +51,3 @@ export async function maintenanceCommand(options: MaintenanceCommandOptions): Pr
 
   console.log();
 }
-
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,10 @@ program
   .option('--no-progress', 'Disable progress bar')
   .action(async (options) => {
     try {
+      const config = await loadConfig();
       await interactiveCommand({
         includeRisky: options.risky,
-        filePicker: options.filePicker,
+        filePicker: options.filePicker ?? config.filePicker,
         absolutePaths: options.absolutePaths,
         noProgress: !options.progress,
       });
@@ -70,13 +71,15 @@ program
 
 program
   .command('maintenance')
-  .description('Run maintenance tasks (DNS flush, free purgeable space)')
+  .description('Run maintenance tasks (DNS flush, free purgeable space, Time Machine snapshots)')
   .option('--dns', 'Flush DNS cache')
   .option('--purgeable', 'Free purgeable space')
+  .option('--timemachine', 'Delete Time Machine local snapshots')
   .action(async (options) => {
     await maintenanceCommand({
       dns: options.dns,
       purgeable: options.purgeable,
+      timemachine: options.timemachine,
     });
   });
 

--- a/src/maintenance/index.ts
+++ b/src/maintenance/index.ts
@@ -1,10 +1,4 @@
 export { flushDnsCache } from './dns-cache.js';
 export { freePurgeableSpace } from './purgeable.js';
+export { clearTimeMachineSnapshots } from './timemachine.js';
 export type { MaintenanceResult } from './dns-cache.js';
-
-
-
-
-
-
-

--- a/src/maintenance/timemachine.ts
+++ b/src/maintenance/timemachine.ts
@@ -1,0 +1,135 @@
+import { spawn } from 'child_process';
+import type { MaintenanceResult } from './dns-cache.js';
+
+const TMUTIL = '/usr/bin/tmutil';
+
+/**
+ * Executes a command using spawn (safer than exec).
+ */
+function execCommand(command: string, args: string[], timeout = 30000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, {
+      timeout,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code: number | null) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(stderr || `Process exited with code ${code}`));
+      }
+    });
+
+    proc.on('error', reject);
+  });
+}
+
+/**
+ * Checks if we can run sudo without a password (non-interactive).
+ */
+async function canSudoWithoutPassword(): Promise<boolean> {
+  try {
+    await execCommand('sudo', ['-n', 'true']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Deletes Time Machine local snapshots on macOS.
+ *
+ * Local snapshots are created automatically by Time Machine and can accumulate
+ * to hundreds of gigabytes. They are safe to delete — macOS will recreate them
+ * as needed once a backup drive is connected.
+ *
+ * Security notes:
+ * - Uses spawn instead of exec to prevent command injection
+ * - Snapshot date strings are validated against a strict regex before use
+ * - Uses sudo -n (non-interactive) to avoid interactive password prompts
+ */
+export async function clearTimeMachineSnapshots(): Promise<MaintenanceResult> {
+  const isRoot = process.getuid?.() === 0;
+
+  // List all local snapshot dates
+  let snapshotOutput: string;
+  try {
+    snapshotOutput = await execCommand(TMUTIL, ['listlocalsnapshotdates']);
+  } catch {
+    return {
+      success: false,
+      message: 'Failed to list Time Machine snapshots',
+      error: 'tmutil not available or Time Machine is not configured on this Mac',
+    };
+  }
+
+  // Snapshot dates have the format "2024-01-15-123456" — validate strictly
+  const DATE_REGEX = /^\d{4}-\d{2}-\d{2}-\d{6}$/;
+  const dates = snapshotOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => DATE_REGEX.test(line));
+
+  if (dates.length === 0) {
+    return {
+      success: true,
+      message: 'No Time Machine local snapshots found',
+    };
+  }
+
+  if (!isRoot) {
+    const canSudo = await canSudoWithoutPassword();
+    if (!canSudo) {
+      return {
+        success: false,
+        message: `Found ${dates.length} snapshot(s) but cannot delete without privileges`,
+        error: 'Run with sudo: sudo mac-cleaner-cli maintenance --timemachine',
+        requiresSudo: true,
+      };
+    }
+  }
+
+  const errors: string[] = [];
+  for (const date of dates) {
+    try {
+      if (isRoot) {
+        await execCommand(TMUTIL, ['deletelocalsnapshots', date], 60000);
+      } else {
+        await execCommand('sudo', ['-n', TMUTIL, 'deletelocalsnapshots', date], 60000);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      errors.push(`${date}: ${msg}`);
+    }
+  }
+
+  const deleted = dates.length - errors.length;
+
+  if (errors.length > 0 && deleted === 0) {
+    return {
+      success: false,
+      message: 'Failed to delete Time Machine snapshots',
+      error: errors[0],
+    };
+  }
+
+  return {
+    success: true,
+    message:
+      errors.length > 0
+        ? `Deleted ${deleted}/${dates.length} Time Machine snapshots (${errors.length} error(s))`
+        : `Deleted ${deleted} Time Machine snapshot${deleted !== 1 ? 's' : ''}`,
+  };
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -25,6 +25,7 @@ export interface Config {
   backupRetentionDays?: number;
   parallelScans?: boolean;
   concurrency?: number;
+  filePicker?: boolean;
   extraPaths?: {
     nodeModules?: string[];
     projects?: string[];
@@ -94,6 +95,10 @@ function validateConfig(config: Partial<Config>): Config {
 
   if (config.parallelScans !== undefined) {
     validated.parallelScans = Boolean(config.parallelScans);
+  }
+
+  if (config.filePicker !== undefined) {
+    validated.filePicker = Boolean(config.filePicker);
   }
 
   // Validate category arrays
@@ -265,6 +270,3 @@ export async function initConfig(): Promise<string> {
   await writeFile(configPath, JSON.stringify(defaultConfig, null, 2));
   return configPath;
 }
-
-
-


### PR DESCRIPTION
## Summary

- **Fix #52:** Adiciona `filePicker?: boolean` à interface `Config` e ao `validateConfig`, para que `"filePicker": true` no `~/.maccleanerrc` seja respeitado. Carrega o config no startup do `src/index.ts` e usa `config.filePicker` como fallback quando a flag `--file-picker` não é passada via CLI.
- **Close #48:** Adiciona task de manutenção `clearTimeMachineSnapshots` em `src/maintenance/timemachine.ts` — usa `spawn` seguro, valida formato das datas antes de passar ao `tmutil`, lida com `sudo` via `sudo -n` (não-interativo). Exposta via `mac-cleaner-cli maintenance --timemachine`.

## Closes

Closes #52, closes #48