### PR TITLE
fix: silence EPERM errors when removing temp files

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -270,7 +270,7 @@ export async function removeItem(path: string, dryRun = false): Promise<boolean>
   } catch (error) {
     // Log the error for debugging but don't expose details to potential attackers
     const code = (error as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT' && code !== 'EACCES') {
+    if (code !== 'ENOENT' && code !== 'EACCES' && code !== 'EPERM') {
       console.error(`Failed to remove ${path}: ${code || 'unknown error'}`);
     }
     return false;


### PR DESCRIPTION
## Summary

- Adds `EPERM` to the list of silenced error codes in `removeItem` alongside `EACCES` and `ENOENT`

## Context

Closes #61. macOS SIP/TCC returns `EPERM` (not `EACCES`) for system-owned temp directories like `/var/folders/.../T/com.apple.*`. Users were seeing dozens of `Failed to remove ... EPERM` lines that are expected and not actionable.

## Test plan
- [ ] Run `mac-cleaner-cli` → select "Temporary Files" → confirm no EPERM spam in output