### PR TITLE
fix: add types:node to tsconfig for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Adds `"types": ["node"]` to `tsconfig.json` compiler options

## Context

TypeScript 6 (coming in dependabot PR #60) no longer implicitly includes Node.js globals. Without this change, `process`, `Buffer`, `NodeJS`, `child_process`, `fs/promises`, `path`, and `os` all fail with `TS2591`. This is a one-liner fix that unblocks that upgrade.

Merging this first makes PR #60 mergeable without any additional changes.

## Test plan
- [x] `npm run typecheck` — passes clean